### PR TITLE
 Update Icon Usage to Standard Font Awesome Icons

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -32,11 +32,11 @@ app_ui <- function() {
                                    shinydashboard::menuSubItem("Weekly Status", tabName = "weekly", icon = icon("calendar",  verify_fa = FALSE)),
                                    shinydashboard::menuSubItem("Workflows Status", tabName = "workflows", icon = icon("tasks",  verify_fa = FALSE))),
           shinydashboard::menuItem("Models", tabName = "models", icon = icon("chart-line",  verify_fa = FALSE),
-                                   shinydashboard::menuSubItem("SIPNET", tabName = "sipnet", icon = icon("square-s",  verify_fa = FALSE)),
+                                   shinydashboard::menuSubItem("SIPNET", tabName = "sipnet", icon = icon("square", lib="font-awesome")),
                                    #shinydashboard::menuSubItem("BIOCRO", tabName = "biocro", icon = icon("square-b",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("ED2.2", tabName = "ed2", icon = icon("square-e",  verify_fa = FALSE)),
+                                   shinydashboard::menuSubItem("ED2.2", tabName = "ed2", icon = icon("square", lib="font-awesome")),
                                    #shinydashboard::menuSubItem("BASGRA", tabName = "basgra", icon = icon("circle-B",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("MAESPA", tabName = "maespa", icon = icon("square-C",  verify_fa = FALSE))
+                                   shinydashboard::menuSubItem("MAESPA", tabName = "maespa", icon = icon("square", lib="font-awesome"))
                                                                      )
         )),
       

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -26,17 +26,17 @@ app_ui <- function() {
       
       shinydashboard::dashboardSidebar(
         shinydashboard::sidebarMenu(
-          shinydashboard::menuItem("Dashboard", tabName = "dashboard", icon = icon("dashboard",  verify_fa = FALSE)),
-          shinydashboard::menuItem("Test", tabName = "test", icon = icon("bolt",  verify_fa = FALSE)),
-          shinydashboard::menuItem("Overall Report", tabName = "report", icon = icon("chart-line",  verify_fa = FALSE),
-                                   shinydashboard::menuSubItem("Weekly Status", tabName = "weekly", icon = icon("calendar",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("Workflows Status", tabName = "workflows", icon = icon("tasks",  verify_fa = FALSE))),
-          shinydashboard::menuItem("Models", tabName = "models", icon = icon("chart-line",  verify_fa = FALSE),
-                                   shinydashboard::menuSubItem("SIPNET", tabName = "sipnet", icon = icon("square", lib="font-awesome")),
+          shinydashboard::menuItem("Dashboard", tabName = "dashboard", icon = shiny::icon("dashboard", lib = "font-awesome")),
+          shinydashboard::menuItem("Test", tabName = "test", icon = icon("bolt",  lib="font-awesome")),
+          shinydashboard::menuItem("Overall Report", tabName = "report", icon = shiny::icon("chart-line",  lib="font-awesome"),
+                                   shinydashboard::menuSubItem("Weekly Status", tabName = "weekly", icon = shiny::icon("calendar",  lib="font-awesome")),
+                                   shinydashboard::menuSubItem("Workflows Status", tabName = "workflows", icon = shiny::icon("tasks",  lib="font-awesome"))),
+          shinydashboard::menuItem("Models", tabName = "models", icon = shiny::icon("chart-line", lib="font-awesome"),
+                                   shinydashboard::menuSubItem("SIPNET", tabName = "sipnet", icon = shiny::icon("square", lib="font-awesome")),
                                    #shinydashboard::menuSubItem("BIOCRO", tabName = "biocro", icon = icon("square-b",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("ED2.2", tabName = "ed2", icon = icon("square", lib="font-awesome")),
+                                   shinydashboard::menuSubItem("ED2.2", tabName = "ed2", icon = shiny::icon("square", lib="font-awesome")),
                                    #shinydashboard::menuSubItem("BASGRA", tabName = "basgra", icon = icon("circle-B",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("MAESPA", tabName = "maespa", icon = icon("square", lib="font-awesome"))
+                                   shinydashboard::menuSubItem("MAESPA", tabName = "maespa", icon = shiny::icon("square", lib="font-awesome"))
                                                                      )
         )),
       


### PR DESCRIPTION
### Decription
This Pull Request introduces changes to the icon usage within the Shiny dashboard application. The primary change is the update of custom or non-standard icon references to standard Font Awesome icons. Specifically, instances of the icon `"square-C"` have been replaced with the standard Font Awesome icon `"square"`. This update ensures compatibility with the Font Awesome library and addresses issues related to non-recognizable icons.

By the end, this PR intends to fix #13.

#### Changes
- Replaced non-standard icon references (such as `"square-C"`) with the standard Font Awesome icon `"square"`.
- Applied this change in all instances where the non-standard icons were used, particularly within `shinydashboard::menuSubItem`.

#### Impact
- These changes should not affect the overall functionality of the application.
- Users should see the standard square icon from Font Awesome instead of the previously intended custom icon. Error logs should disappear too by the end of PR.

#### Note
- This PR is a part of ongoing debugging efforts. Although this update addresses specific icon-related issues, further investigation and fixes may be required to resolve other error logs as mentioned previously.
- Feedback and additional insights into the error logs are welcome to aid in comprehensive troubleshooting.