### PR TITLE
Configure `/config/config.R`

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -26,17 +26,17 @@ app_ui <- function() {
       
       shinydashboard::dashboardSidebar(
         shinydashboard::sidebarMenu(
-          shinydashboard::menuItem("Dashboard", tabName = "dashboard", icon = icon("dashboard",  verify_fa = FALSE)),
-          shinydashboard::menuItem("Test", tabName = "test", icon = icon("bolt",  verify_fa = FALSE)),
-          shinydashboard::menuItem("Overall Report", tabName = "report", icon = icon("chart-line",  verify_fa = FALSE),
-                                   shinydashboard::menuSubItem("Weekly Status", tabName = "weekly", icon = icon("calendar",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("Workflows Status", tabName = "workflows", icon = icon("tasks",  verify_fa = FALSE))),
-          shinydashboard::menuItem("Models", tabName = "models", icon = icon("chart-line",  verify_fa = FALSE),
-                                   shinydashboard::menuSubItem("SIPNET", tabName = "sipnet", icon = icon("square", lib="font-awesome")),
+          shinydashboard::menuItem("Dashboard", tabName = "dashboard", icon = shiny::icon("dashboard", lib = "font-awesome")),
+          shinydashboard::menuItem("Test", tabName = "test", icon = icon("bolt",  lib="font-awesome")),
+          shinydashboard::menuItem("Overall Report", tabName = "report", icon = shiny::icon("chart-line",  lib="font-awesome"),
+                                   shinydashboard::menuSubItem("Weekly Status", tabName = "weekly", icon = shiny::icon("calendar",  lib="font-awesome")),
+                                   shinydashboard::menuSubItem("Workflows Status", tabName = "workflows", icon = shiny::icon("tasks",  lib="font-awesome"))),
+          shinydashboard::menuItem("Models", tabName = "models", icon = shiny::icon("chart-line", lib="font-awesome"),
+                                   shinydashboard::menuSubItem("SIPNET", tabName = "sipnet", icon = shiny::icon("square", lib="font-awesome")),
                                    #shinydashboard::menuSubItem("BIOCRO", tabName = "biocro", icon = icon("square-b",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("ED2.2", tabName = "ed2", icon = icon("square", lib="font-awesome")),
+                                   shinydashboard::menuSubItem("ED2.2", tabName = "ed2", icon = shiny::icon("square", lib="font-awesome")),
                                    #shinydashboard::menuSubItem("BASGRA", tabName = "basgra", icon = icon("circle-B",  verify_fa = FALSE)),
-                                   shinydashboard::menuSubItem("MAESPA", tabName = "maespa", icon = icon("square", lib="font-awesome"))
+                                   shinydashboard::menuSubItem("MAESPA", tabName = "maespa", icon = shiny::icon("square", lib="font-awesome"))
                                                                      )
         )),
       

--- a/R/fct_workflow_status.R
+++ b/R/fct_workflow_status.R
@@ -11,7 +11,7 @@
 
 
 workflow_status <- function(report){
-  server <- rpecanapi::connect("http://141.142.217.168/", "carya", "illinois")
+  server <- rpecanapi::connect("http://pecan.localhost/", "carya", "illinois")
   id <- report$workflow_id
   result <- data.frame()
   for (i in id) {

--- a/R/fct_workflow_status.R
+++ b/R/fct_workflow_status.R
@@ -8,7 +8,7 @@
 #' @import tibble
 #'
 #' @noRd
-source("../config/config.R")
+source("config/config.R")
 host_url <- host_url
 
 workflow_status <- function(report){

--- a/R/fct_workflow_status.R
+++ b/R/fct_workflow_status.R
@@ -8,10 +8,12 @@
 #' @import tibble
 #'
 #' @noRd
-
+source("../config/config.R")
+host_url <- host_url
 
 workflow_status <- function(report){
-  server <- rpecanapi::connect("http://pecan.localhost/", "carya", "illinois")
+  library(rpecanapi)
+  server <- rpecanapi::connect(host_url, "carya", "illinois")
   id <- report$workflow_id
   result <- data.frame()
   for (i in id) {

--- a/R/fct_workflow_status.R
+++ b/R/fct_workflow_status.R
@@ -9,10 +9,8 @@
 #'
 #' @noRd
 source("config/config.R")
-host_url <- host_url
 
 workflow_status <- function(report){
-  library(rpecanapi)
   server <- rpecanapi::connect(host_url, "carya", "illinois")
   id <- report$workflow_id
   result <- data.frame()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ library("statusboard")
 
 ### Running The Dashboard
 
-Now, within the `config/config.R` file, you can set the `host_url` to the PEcAn API server you want to monitor. By default, it is set to the PEcAn API server hosted at [http://pecan.localhost/](http://pecan.localhost/).
+Now, within the `config/config.R` file, you can set the `host_url` to the PEcAn dockerised server you want to monitor. By default, it is set to the PEcAn API server hosted at [http://pecan.localhost/](http://pecan.localhost/).
 
 ``` r
 # Run this code to start the dashboard locally

--- a/README.md
+++ b/README.md
@@ -29,15 +29,20 @@ The PEcan Status Board can be installed locally from [GitHub](https://github.com
 # install.packages("devtools")
 devtools::install_github("PecanProject/pecan-status-board")
 ```
-``` r 
+
+``` r
 library("statusboard")
 ```
+
 ### Running The Dashboard
+
+Now, within the `config/config.R` file, you can set the `host_url` to the PEcAn API server you want to monitor. By default, it is set to the PEcAn API server hosted at [http://pecan.localhost/](http://pecan.localhost/).
+
 ``` r
 # Run this code to start the dashboard locally
 statusboard::run_app()
-
 ```
+
 ## Visualization
 
 Data Visualization refers to the graphical representation of information and data in the form of a graph, or chart, or bar, or any other format. The purpose of Data Visualization is to convey information and results quickly and easily.

--- a/config/config.R
+++ b/config/config.R
@@ -1,0 +1,2 @@
+# This is the URL that the R package will use to connect to the Pecan service.
+host_url <- "http://pecan.localhost/"

--- a/inst/ed2-test.R
+++ b/inst/ed2-test.R
@@ -7,7 +7,7 @@ library(httr)
 library(glue)
 
 # Modify for your target machine and authentication
-server <- connect("http://141.142.217.168/", "ashiklom", "admin")
+server <- connect("http://pecan.localhost/", "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/ed2-test.R
+++ b/inst/ed2-test.R
@@ -5,9 +5,11 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
+source("../config/config.R")
+host_url <- host_url
 
 # Modify for your target machine and authentication
-server <- connect("http://pecan.localhost/", "ashiklom", "admin")
+server <- connect(host_url, "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/ed2-test.R
+++ b/inst/ed2-test.R
@@ -5,7 +5,7 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
-source("../config/config.R")
+source("config/config.R")
 host_url <- host_url
 
 # Modify for your target machine and authentication

--- a/inst/ed2-test.R
+++ b/inst/ed2-test.R
@@ -6,7 +6,6 @@ library(purrr)
 library(httr)
 library(glue)
 source("config/config.R")
-host_url <- host_url
 
 # Modify for your target machine and authentication
 server <- connect(host_url, "ashiklom", "admin")

--- a/inst/maespa-test.R
+++ b/inst/maespa-test.R
@@ -7,7 +7,7 @@ library(httr)
 library(glue)
 
 # Modify for your target machine and authentication
-server <- connect("http://141.142.217.168/", "ashiklom", "admin")
+server <- connect("http://pecan.localhost/", "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/maespa-test.R
+++ b/inst/maespa-test.R
@@ -5,9 +5,11 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
+source("../config/config.R")
+host_url <- host_url
 
 # Modify for your target machine and authentication
-server <- connect("http://pecan.localhost/", "ashiklom", "admin")
+server <- connect(host_url, "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/maespa-test.R
+++ b/inst/maespa-test.R
@@ -5,7 +5,7 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
-source("../config/config.R")
+source("config/config.R")
 host_url <- host_url
 
 # Modify for your target machine and authentication

--- a/inst/maespa-test.R
+++ b/inst/maespa-test.R
@@ -6,7 +6,6 @@ library(purrr)
 library(httr)
 library(glue)
 source("config/config.R")
-host_url <- host_url
 
 # Modify for your target machine and authentication
 server <- connect(host_url, "ashiklom", "admin")

--- a/inst/run-test-list.R
+++ b/inst/run-test-list.R
@@ -7,7 +7,7 @@ library(httr)
 library(glue)
 
 # Modify for your target machine and authentication
-server <- connect("http://141.142.217.168/", "ashiklom", "admin")
+server <- connect("http://pecan.localhost/", "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/run-test-list.R
+++ b/inst/run-test-list.R
@@ -5,9 +5,11 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
+source("../config/config.R")
+host_url <- host_url
 
 # Modify for your target machine and authentication
-server <- connect("http://pecan.localhost/", "ashiklom", "admin")
+server <- connect(host_url, "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/run-test-list.R
+++ b/inst/run-test-list.R
@@ -5,7 +5,7 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
-source("../config/config.R")
+source("config/config.R")
 host_url <- host_url
 
 # Modify for your target machine and authentication

--- a/inst/run-test-list.R
+++ b/inst/run-test-list.R
@@ -6,7 +6,6 @@ library(purrr)
 library(httr)
 library(glue)
 source("config/config.R")
-host_url <- host_url
 
 # Modify for your target machine and authentication
 server <- connect(host_url, "ashiklom", "admin")

--- a/inst/sipnet-test.R
+++ b/inst/sipnet-test.R
@@ -7,7 +7,7 @@ library(httr)
 library(glue)
 
 # Modify for your target machine and authentication
-server <- connect("http://141.142.217.168/", "ashiklom", "admin")
+server <- connect("http://pecan.localhost/", "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/sipnet-test.R
+++ b/inst/sipnet-test.R
@@ -5,9 +5,11 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
+source("../config/config.R")
+host_url <- host_url
 
 # Modify for your target machine and authentication
-server <- connect("http://pecan.localhost/", "ashiklom", "admin")
+server <- connect(host_url, "ashiklom", "admin")
 
 # List all available models
 models <- GET(

--- a/inst/sipnet-test.R
+++ b/inst/sipnet-test.R
@@ -5,7 +5,7 @@ library(tibble)
 library(purrr)
 library(httr)
 library(glue)
-source("../config/config.R")
+source("config/config.R")
 host_url <- host_url
 
 # Modify for your target machine and authentication

--- a/inst/sipnet-test.R
+++ b/inst/sipnet-test.R
@@ -6,7 +6,6 @@ library(purrr)
 library(httr)
 library(glue)
 source("config/config.R")
-host_url <- host_url
 
 # Modify for your target machine and authentication
 server <- connect(host_url, "ashiklom", "admin")


### PR DESCRIPTION
Suggestions initially added by @infotroph for the `pecan-status-board` to directly fetch our local dockerised server (`http://pecan.localhost/`) instead of `http://141.142.216.168/` which was a virtual machine at NCSA that’s apparently down.